### PR TITLE
feat(housing): refresh listings and expose lotto info

### DIFF
--- a/src/commands/housing/embed.ts
+++ b/src/commands/housing/embed.ts
@@ -14,19 +14,32 @@ import { DISTRICT_IMAGES } from '../../const/housing/housing';
 export function plotEmbed(p: Plot, refreshedAt?: Date) {
     const status = formatStatus(p);
     const embed = new EmbedBuilder()
-        .setTitle(`${p.world} - ${p.district} Ward ${p.ward} Plot ${p.plot}`)
+        .setTitle(`🏠 ${p.world} - ${p.district} Ward ${p.ward} Plot ${p.plot}`)
         .addFields(
-            { name: 'Datacenter', value: p.dataCenter, inline: true },
-            { name: 'World', value: p.world, inline: true },
-            { name: 'District', value: p.district, inline: true },
-            { name: 'Price', value: p.price != null ? `${p.price.toLocaleString()} gil` : '-', inline: true },
-            { name: 'Size', value: p.size ?? '-', inline: true },
-            { name: 'FC Available', value: p.ward <= 20 ? 'Yes' : 'No', inline: true },
+            { name: '🗺️ Datacenter', value: p.dataCenter, inline: true },
+            { name: '🌐 World', value: p.world, inline: true },
+            { name: '🏘️ District', value: p.district, inline: true },
+            { name: '💰 Price', value: p.price != null ? `${p.price.toLocaleString()} gil` : '-', inline: true },
+            { name: '📏 Size', value: p.size ?? '-', inline: true },
+            { name: '👥 FC Available', value: p.ward <= 20 ? 'Yes' : 'No', inline: true },
         )
         .setFooter({ text: `${new Date().toLocaleString()} • ${status}` });
 
+    if (p.lottery.entries != null) {
+        embed.addFields({ name: '🎟️ Lotto Entries', value: String(p.lottery.entries), inline: true });
+    }
+
+    if (p.lastUpdated != null) {
+        embed.addFields({ name: '⏱️ Last Updated', value: new Date(p.lastUpdated).toLocaleString(), inline: true });
+    }
+
+    if (p.lottery.phaseUntil != null) {
+        const ts = Math.floor(p.lottery.phaseUntil / 1000);
+        embed.addFields({ name: '📅 Lotto Phase Until', value: `<t:${ts}:F>`, inline: true });
+    }
+
     if (refreshedAt) {
-        embed.addFields({ name: 'Refreshed at', value: refreshedAt.toLocaleString(), inline: false });
+        embed.addFields({ name: '🔄 Refreshed at', value: refreshedAt.toLocaleString(), inline: false });
     }
 
     const imgFile = DISTRICT_IMAGES[p.district];


### PR DESCRIPTION
## Summary
- update stored housing posts with refreshed timestamps
- show lottery entries, phase end and API update time in housing embeds
- parse additional lottery metadata from PaissaDB
- display lottery phase end as a Discord timestamp and auto-delete expired messages via watcher

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b592193d248321a60e75581ef77c17