### PR TITLE
feat: add housing schedule configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { commands } from './handlers/commandInit.js';
 import { commandHandler } from './handlers/commandHandler.js';
 import { registerEvents } from './events/index.js';
 import { startHousingMessageWatcher } from './watchers/housingMessageWatcher.js';
+import { startHousingScheduler } from './functions/housing/housingScheduler.js';
 import { botConfig } from './config.js';
 
 // Ensure the Discord token is available. Without it the bot cannot start.
@@ -29,6 +30,7 @@ commandHandler.registerAll(commands);
 // Set up event listeners.
 registerEvents(client);
 startHousingMessageWatcher(client);
+startHousingScheduler(client);
 
 // Finally log in using the provided token. Any login failure is fatal.
 client.login(token).catch((e) => {


### PR DESCRIPTION
## Summary
- add interactive schedule configuration for housing feature
- start recurring housing refresh scheduler on bot startup

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b6e0a5ca4c83218b2b959631cc7b60