### PR TITLE
feat: improve housing setup and scheduler

### DIFF
--- a/src/commands/housing/housing.ts
+++ b/src/commands/housing/housing.ts
@@ -8,7 +8,7 @@ import {
 } from "discord.js";
 import type { Command } from "../../handlers/commandHandler";
 
-import start from './housingStart';
+import setup from './housingSetup';
 import refresh from './housingRefresh';
 import research from './housingResearch';
 
@@ -20,7 +20,7 @@ type Sub = {
     autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
 };
 
-const SUBS: Sub[] = [start, refresh, research];
+const SUBS: Sub[] = [setup, refresh, research];
 
 export const data = (() => {
     const command = new SlashCommandBuilder()

--- a/src/functions/housing/housingRefresh.ts
+++ b/src/functions/housing/housingRefresh.ts
@@ -347,7 +347,7 @@ export async function refreshHousing(client: Client, guildID: string) {
 
   return { added, removed, updated, elapsedMs };
     },
-    { guildId: guildID, blockWith: ['housing:start'] }
+    { guildId: guildID, blockWith: ['housing:setup'] }
   );
 }
 

--- a/src/functions/housing/housingScheduler.ts
+++ b/src/functions/housing/housingScheduler.ts
@@ -3,9 +3,42 @@ import { configManager } from '../../handlers/configHandler';
 import { HousingRequired } from '../../schemas/housing';
 import { refreshHousing } from './housingRefresh';
 import { logError } from '../../handlers/errorHandler.js';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 
 type S = { last?: number; runs: number; day: string; running: boolean };
 const state = new Map<string, S>();
+const stateFile = path.join(process.cwd(), 'src', 'json', 'housing_scheduler_state.json');
+
+async function loadState() {
+    try {
+        const raw = await readFile(stateFile, 'utf8');
+        const obj = JSON.parse(raw) as Record<string, { last?: number; runs: number; day: string }>;
+        for (const [gid, s] of Object.entries(obj)) {
+            const st: S = { runs: s.runs, day: s.day, running: false };
+            if (typeof s.last === 'number') st.last = s.last;
+            state.set(gid, st);
+        }
+    } catch {
+        /* ignore */
+    }
+}
+
+async function saveState() {
+    const obj: Record<string, { last?: number; runs: number; day: string }> = {};
+    for (const [gid, s] of state) {
+        const rec: { last?: number; runs: number; day: string } = { runs: s.runs, day: s.day };
+        if (typeof s.last === 'number') rec.last = s.last;
+        obj[gid] = rec;
+    }
+    try {
+        await writeFile(stateFile, JSON.stringify(obj, null, 2), 'utf8');
+    } catch (err) {
+        logError('housing scheduler state save', err);
+    }
+}
+
+loadState();
 
 function dayKey(d = new Date()): string {
     return `${d.getUTCFullYear()}-${String(d.getUTCMonth()+1).padStart(2,'0')}-${String(d.getUTCDate()).padStart(2,'0')}`;
@@ -14,6 +47,7 @@ function dayKey(d = new Date()): string {
 export function startHousingScheduler(client: Client) {
     setInterval(async () => {
         const today = dayKey();
+        let changed = false;
 
         for (const [guildID] of client.guilds.cache) {
             try {
@@ -27,6 +61,7 @@ export function startHousingScheduler(client: Client) {
                 if (st.day !== today) {
                     st.runs = 0;
                     st.day = today;
+                    changed = true;
                 }
 
                 if (st.running) continue;
@@ -42,6 +77,7 @@ export function startHousingScheduler(client: Client) {
                         await refreshHousing(client, guildID);
                         st.last = Date.now();
                         st.runs += 1;
+                        changed = true;
                     } finally {
                         st.running = false;
                     }
@@ -51,5 +87,7 @@ export function startHousingScheduler(client: Client) {
                 logError(`housing scheduler for guild ${guildID}`, err);
             }
         }
+
+        if (changed) await saveState();
     }, 60_000);
 }

--- a/src/lib/threadManager.ts
+++ b/src/lib/threadManager.ts
@@ -70,6 +70,12 @@ export class ThreadManager {
 
     return this.exec([...keys], fn);
   }
+
+  isLocked(task: string, opts: ThreadOptions = {}): boolean {
+    const { guildId } = opts;
+    const key = guildId ? `${task}:${guildId}` : task;
+    return this.queues.has(key);
+  }
 }
 
 export const threadManager = new ThreadManager();


### PR DESCRIPTION
## Summary
- rename `/housing start` to `/housing setup`
- prevent setup while a housing refresh is running
- persist housing refresh scheduler state and reuse stable message hashes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b969c73b2c8321a5382a1cf0a3db97