### PR TITLE
Simplify housing scheduler configuration

### DIFF
--- a/src/commands/config/housingConfig.ts
+++ b/src/commands/config/housingConfig.ts
@@ -39,7 +39,6 @@ async function handle(interaction: ChatInputCommandInteraction) {
         districts: h.districts ?? [],
         channelId: h.channelId,
         timesPerDay: h.timesPerDay,
-        intervalMinutes: h.intervalMinutes,
         pingUserId: h.pingUserId,
         pingRoleId: h.pingRoleId,
     });
@@ -144,7 +143,6 @@ async function handle(interaction: ChatInputCommandInteraction) {
       districts: h.districts ?? [],
       channelId: h.channelId,
       timesPerDay: h.timesPerDay,
-      intervalMinutes: h.intervalMinutes,
       pingUserId: h.pingUserId,
       pingRoleId: h.pingRoleId,
     }),
@@ -178,7 +176,6 @@ export function summaryContent(s: {
   districts: string[];
   channelId?: string;
   timesPerDay?: number;
-  intervalMinutes?: number;
   pingUserId?: string;
   pingRoleId?: string;
 }) {
@@ -188,11 +185,7 @@ export function summaryContent(s: {
 - Worlds: ${s.worlds.join(", ") || "—"}
 - Districts: ${s.districts.join(", ") || "—"}
 - Channel: ${s.channelId ? `<#${s.channelId}>` : "—"}
-- Auto: ${
-    s.timesPerDay && s.intervalMinutes
-      ? `${s.timesPerDay}×/Tag, alle ${s.intervalMinutes} Min`
-      : "—"
-  }
+- Auto: ${s.timesPerDay ? `${s.timesPerDay}×/Tag` : "—"}
 - Ping User: ${s.pingUserId ? `<@${s.pingUserId}>` : "—"}
 - Ping Role: ${s.pingRoleId ? `<@&${s.pingRoleId}>` : "—"}`;
 }

--- a/src/events/housing/housingInteraction.ts
+++ b/src/events/housing/housingInteraction.ts
@@ -29,7 +29,6 @@ async function refreshSummary(interaction: RepliableInteraction, key: string) {
                 districts: draft.districts ?? [],
                 ...(draft.channelId ? { channelId: draft.channelId } : {}),
                 ...(draft.timesPerDay !== undefined ? { timesPerDay: draft.timesPerDay } : {}),
-                ...(draft.intervalMinutes !== undefined ? { intervalMinutes: draft.intervalMinutes } : {}),
                 ...(draft.pingUserId ? { pingUserId: draft.pingUserId } : {}),
                 ...(draft.pingRoleId ? { pingRoleId: draft.pingRoleId } : {}),
             }),
@@ -50,25 +49,6 @@ function buildTimesRow(selected?: number) {
                         .setLabel(`${n}×/Tag`)
                         .setValue(String(n))
                         .setDefault(selected === n)
-                ),
-            )
-            .setMinValues(1)
-            .setMaxValues(1),
-    );
-}
-
-function buildIntervalRow(selected?: number) {
-    const opts = [480, 720, 960, 1440];
-    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-        new StringSelectMenuBuilder()
-            .setCustomId(HOUSING_PREFIX + 'interval')
-            .setPlaceholder('Abstand (Minuten)')
-            .addOptions(
-                opts.map(m =>
-                    new StringSelectMenuOptionBuilder()
-                        .setLabel(`${Math.floor(m / 60)}h`)
-                        .setValue(String(m))
-                        .setDefault(selected === m)
                 ),
             )
             .setMinValues(1)
@@ -277,7 +257,6 @@ export function register(client: Client) {
                             content: 'Automatische Aktualisierung konfigurieren:',
                             components: [
                                 buildTimesRow(draft?.timesPerDay),
-                                buildIntervalRow(draft?.intervalMinutes),
                             ],
                             flags: MessageFlags.Ephemeral,
                         });
@@ -293,18 +272,6 @@ export function register(client: Client) {
                         await interaction.update({ components: rows });
                         await refreshSummary(interaction, key);
                         await transientReply(interaction, `Runs pro Tag auf **${timesPerDay}** gesetzt.`);
-                    }
-                    break;
-                case 'interval':
-                    if (interaction.isStringSelectMenu()) {
-                        const intervalMinutes = Number(interaction.values[0]);
-                        const draft = setDraft(key, { intervalMinutes });
-                        await configManager.update(interaction.guildId, 'housing', draft);
-                        const rows: any[] = [...interaction.message.components];
-                        rows[1] = buildIntervalRow(intervalMinutes);
-                        await interaction.update({ components: rows });
-                        await refreshSummary(interaction, key);
-                        await transientReply(interaction, `Intervall auf **${intervalMinutes}** Minuten gesetzt.`);
                     }
                     break;
                 default:

--- a/src/functions/housing/housingScheduler.ts
+++ b/src/functions/housing/housingScheduler.ts
@@ -74,7 +74,7 @@ export function startHousingScheduler(client: Client) {
                     threadManager.isLocked('housing:reset', { guildId: guildID }) 
                 ) continue;
 
-                const minGap = req.data.intervalMinutes * 60 * 1000;
+                const minGap = (1440 / req.data.timesPerDay) * 60 * 1000;
                 const now = Date.now();
                 const gapOK = !st.last || now - st.last >= minGap;
                 const capOK = st.runs < req.data.timesPerDay;

--- a/src/schemas/housing.ts
+++ b/src/schemas/housing.ts
@@ -10,13 +10,12 @@ export const housingPartial = z.object({
     districts: z.array(z.string()).optional(),
     channelId: z.string().min(1).optional(),
     timesPerDay: z.number().int().min(1).max(3).optional(),
-    intervalMinutes: z.number().int().min(480).max(1440).optional(),
     pingUserId: z.string().min(1).optional(),
     pingRoleId: z.string().min(1).optional(),
 });
 
 // Minimal schema required for posting housing listings manually.
-// Scheduler-specific fields like timesPerDay/intervalMinutes are omitted.
+// Scheduler-specific fields like timesPerDay are omitted.
 export const HousingStart = z.object({
     enabled: z.literal(true),
     dataCenter: z.string().min(1),
@@ -36,7 +35,6 @@ export const HousingRequired = z.object({
     districts: z.array(z.string()).nonempty(),
     channelId: z.string().min(1),
     timesPerDay: z.number().int().min(1).max(3),
-    intervalMinutes: z.number().int().min(480).max(1440),
     pingUserId: z.string().min(1).optional(),
     pingRoleId: z.string().min(1).optional(),
 });

--- a/src/ui/housingUI.ts
+++ b/src/ui/housingUI.ts
@@ -9,7 +9,6 @@ export type HousingDraft = {
     districts?: string[];
     channelId?: string;
     timesPerDay?: number;
-    intervalMinutes?: number;
     pingUserId?: string;
     pingRoleId?: string;
     /** ID of the summary message so it can be edited later. */


### PR DESCRIPTION
## Summary
- Derive housing refresh interval from daily run count, allowing up to three runs spaced evenly across the day
- Drop interval selection from UI and config, leaving a single option for runs per day
- Remove intervalMinutes from housing schema and drafts

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bb3b8478248321ba7b38459f74cca7