### PR TITLE
Fix housing setup/refresh filtering for PaissaDB plots

### DIFF
--- a/src/embeds/housingEmbeds.ts
+++ b/src/embeds/housingEmbeds.ts
@@ -54,9 +54,15 @@ export function plotEmbed(p: Plot, refreshedAt?: Date) {
         // Footer shows generation + refresh timestamps
         .setFooter({ text: `Posted: ${new Date().toLocaleString()} • Refreshed: ${refreshedAt?.toLocaleString() ?? '-'}` });
 
-    // Add optional field: number of lottery entries
+    // Add field for lottery entries or note when PaissaDB lacks placard data
     if (p.lottery.entries != null) {
         embed.addFields({ name: '🎟️ Lotto Entries', value: String(p.lottery.entries), inline: true });
+    } else {
+        embed.addFields({
+            name: '🎟️ Lotto Entries',
+            value: 'No data – plot may already be sold or unavailable (verify in-game)',
+            inline: false,
+        });
     }
 
     // Add optional field: last update timestamp from PaissaDB API

--- a/src/functions/housing/housingProvider.paissa.ts
+++ b/src/functions/housing/housingProvider.paissa.ts
@@ -143,6 +143,7 @@ export class PaissaProvider {
     const wanted = new Set(districts);
 
     const out: Plot[] = [];
+    const now = Date.now();
 
     // Iterate distrcits
     for (const d of detail.districts) {
@@ -182,12 +183,16 @@ export class PaissaProvider {
             // FC-only flag
             if (typeof p.free_company_only === 'boolean') item.fcOnly = p.free_company_only;
 
-            // Last update time (seconds -> ms)
-            if (p.last_updated_time !== undefined) item.lastUpdated = Number(p.last_updated_time) * 1000;
+              // Last update time (seconds -> ms)
+              if (p.last_updated_time !== undefined) item.lastUpdated = Number(p.last_updated_time) * 1000;
 
-            out.push(item);
+              // Skip ward 0 or expired lottery entries
+              if (item.ward <= 0) continue;
+              if (item.lottery?.phaseUntil && item.lottery.phaseUntil <= now) continue;
+
+              out.push(item);
+          }
         }
-      }
-      return out;
+        return out;
     }
   }

--- a/src/functions/housing/housingUtils.ts
+++ b/src/functions/housing/housingUtils.ts
@@ -1,0 +1,41 @@
+import type { Plot } from './housingProvider.paissa.js';
+
+// Normalize district names: strip leading "the", lowercase, trim
+function normDistrict(d: string): string {
+  return d.replace(/^the\s+/i, '').trim().toLowerCase();
+}
+
+/**
+ * Create a stable key for a plot combining datacenter, world,
+ * normalized district, ward and plot numbers. Keys are stored in
+ * lowercase to avoid case-sensitivity issues between runs.
+ */
+export function plotKey(p: Plot): string {
+  return [
+    p.dataCenter.toLowerCase(),
+    p.world.toLowerCase(),
+    normDistrict(p.district),
+    p.ward,
+    p.plot,
+  ].join(':');
+}
+
+/**
+ * Hash of the visible plot information used to detect changes.
+ */
+export function plotHash(p: Plot): string {
+  const stable = {
+    dataCenter: p.dataCenter,
+    world: p.world,
+    district: p.district,
+    ward: p.ward,
+    plot: p.plot,
+    size: p.size,
+    price: p.price,
+    lottery: {
+      phaseUntil: p.lottery?.phaseUntil ?? null,
+      entrants: p.lottery?.entries ?? null,
+    },
+  };
+  return JSON.stringify(stable);
+}


### PR DESCRIPTION
## Summary
- add shared plotKey/plotHash utilities for consistent message tracking
- centralize plot filtering in PaissaProvider and skip ward 0 or expired lotteries
- update housing setup and refresh commands to use new utilities and provider filtering
- show embed notice when PaissaDB returns plots without placard data

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5ba371c2c8321a01bee0b496340e5