### PR TITLE
Improve free company formed date and crest parsing

### DIFF
--- a/src/commands/profile/profileCompany.ts
+++ b/src/commands/profile/profileCompany.ts
@@ -59,6 +59,41 @@ const FOCUS_EMOJI_MAP: Record<string, string> = {
     hardcore: '<:Hardcore:1418907822044876892>',
 };
 
+const FOCUS_DISPLAY_ALIASES = new Map<string, string>();
+
+const addFocusAlias = (display: string, alias: string) => {
+    const normalized = normalizeFocusValue(alias);
+    if (!normalized) return;
+    if (!FOCUS_DISPLAY_ALIASES.has(normalized)) {
+        FOCUS_DISPLAY_ALIASES.set(normalized, display);
+    }
+
+    const compact = normalized.replace(/\s+/g, '');
+    if (compact !== normalized && !FOCUS_DISPLAY_ALIASES.has(compact)) {
+        FOCUS_DISPLAY_ALIASES.set(compact, display);
+    }
+};
+
+const registerFocusDisplay = (display: string, aliases: string[]) => {
+    const trimmedDisplay = display.trim();
+    if (!trimmedDisplay) return;
+
+    addFocusAlias(trimmedDisplay, trimmedDisplay);
+    for (const alias of aliases) {
+        addFocusAlias(trimmedDisplay, alias);
+    }
+};
+
+registerFocusDisplay('Role-playing', ['role-playing', 'roleplaying', 'roleplay']);
+registerFocusDisplay('Leveling', ['leveling']);
+registerFocusDisplay('Casual', ['casual']);
+registerFocusDisplay('Hardcore', ['hardcore']);
+registerFocusDisplay('Dungeons', ['dungeons', 'dungeon']);
+registerFocusDisplay('Guildhests', ['guildhests', 'guildhest', 'gildhests']);
+registerFocusDisplay('Trials', ['trials', 'trial']);
+registerFocusDisplay('Raids', ['raids', 'raid']);
+registerFocusDisplay('PvP', ['pvp']);
+
 const getFocusEmoji = (value: string): string | null => {
     const normalized = normalizeFocusValue(value);
     if (!normalized) return null;
@@ -66,12 +101,76 @@ const getFocusEmoji = (value: string): string | null => {
     return FOCUS_EMOJI_MAP[normalized] ?? FOCUS_EMOJI_MAP[compact] ?? null;
 };
 
+const expandFocusValue = (value: string): string[] => {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+
+    const normalized = normalizeFocusValue(trimmed);
+    if (!normalized) return [];
+
+    const padded = ` ${normalized} `;
+    const matches: Array<{ display: string; alias: string; index: number }> = [];
+
+    for (const [alias, display] of FOCUS_DISPLAY_ALIASES) {
+        const search = ` ${alias} `;
+        const index = padded.indexOf(search);
+        if (index === -1) continue;
+        matches.push({ display, alias, index });
+    }
+
+    if (!matches.length) {
+        const canonical = FOCUS_DISPLAY_ALIASES.get(normalized);
+        if (canonical) return [canonical];
+        return [trimmed];
+    }
+
+    matches.sort((a, b) => a.index - b.index);
+
+    const canonicalMatches: Array<{ display: string; alias: string }> = [];
+    const seenCanonical = new Set<string>();
+
+    for (const match of matches) {
+        const canonicalKey = normalizeFocusValue(match.display);
+        if (!canonicalKey || seenCanonical.has(canonicalKey)) continue;
+        seenCanonical.add(canonicalKey);
+        canonicalMatches.push({ display: match.display, alias: match.alias });
+    }
+
+    if (canonicalMatches.length === 1) {
+        const single = canonicalMatches[0];
+        if (!single) return [trimmed];
+
+        const display = single.display.trim();
+        if (!display) return [trimmed];
+        return [display];
+    }
+
+    if (canonicalMatches.length > 1) {
+        return canonicalMatches.map(match => match.display);
+    }
+
+    return [trimmed];
+};
+
 const formatFocusList = (values: string[]): string | null => {
     if (!values.length) return null;
-    const formatted = values.map(value => {
-        const emoji = getFocusEmoji(value);
-        return emoji ? `${emoji} ${value}` : value;
-    });
+    const formatted: string[] = [];
+    const seen = new Set<string>();
+
+    for (const value of values) {
+        if (typeof value !== 'string') continue;
+        const expanded = expandFocusValue(value);
+
+        for (const entry of expanded) {
+            const normalized = normalizeFocusValue(entry);
+            if (!normalized || seen.has(normalized)) continue;
+            seen.add(normalized);
+
+            const emoji = getFocusEmoji(entry);
+            formatted.push(emoji ? `${emoji} ${entry}` : entry);
+        }
+    }
+
     return formatted.length ? formatted.join(', ') : null;
 };
 

--- a/src/functions/profile/profileFreeCompanyAPI.ts
+++ b/src/functions/profile/profileFreeCompanyAPI.ts
@@ -178,6 +178,70 @@ const parseIconList = (raw: string): string[] => {
     return Array.from(unique.values());
 };
 
+const timestampToIsoDate = (timestamp: number): string | null => {
+    if (!Number.isFinite(timestamp)) return null;
+
+    const date = new Date(timestamp * 1000);
+    if (Number.isNaN(date.getTime())) return null;
+
+    const year = String(date.getUTCFullYear()).padStart(4, '0');
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+};
+
+const parseFormedDetail = (detail: { raw: string; text: string }): string | null => {
+    const textValue = detail.text?.trim();
+    if (textValue) return textValue;
+
+    const timestampMatch = /ldst_strftime\(\s*(\d+)\s*,/i.exec(detail.raw)
+        ?? /data-js-datetime-value="(\d+)"/i.exec(detail.raw);
+    const timestamp = timestampMatch?.[1] ? Number(timestampMatch[1]) : null;
+
+    if (timestamp !== null) {
+        const iso = timestampToIsoDate(timestamp);
+        if (iso) return iso;
+    }
+
+    const fallback = decodeHTML(detail.raw);
+    return fallback || null;
+};
+
+const extractFormedDateFromHtml = (html: string): string | null => {
+    const formedSectionMatch = /<h3[^>]*class="[^"]*heading--lead[^"]*"[^>]*>[\s\S]*?Formed[\s\S]*?<\/h3>([\s\S]*?)(?=<h3[^>]*class="[^"]*heading--lead[^"]*"[^>]*>|<\/section>)/i.exec(html);
+    const sections = [formedSectionMatch?.[1], html];
+
+    for (const section of sections) {
+        if (!section) continue;
+
+        const timestampMatches = Array.from(section.matchAll(/ldst_strftime\(\s*(\d+)\s*,/gi));
+        for (const match of timestampMatches) {
+            const iso = match?.[1] ? timestampToIsoDate(Number(match[1])) : null;
+            if (iso) return iso;
+        }
+
+        const dataValueMatches = Array.from(section.matchAll(/data-js-datetime-value="(\d+)"/gi));
+        for (const match of dataValueMatches) {
+            const iso = match?.[1] ? timestampToIsoDate(Number(match[1])) : null;
+            if (iso) return iso;
+        }
+
+        const spanMatch = /<span[^>]+id="datetime-[^"]+"[^>]*>([\s\S]*?)<\/span>/i.exec(section);
+        if (spanMatch) {
+            const spanText = decodeHTML(spanMatch[1] ?? '').trim();
+            if (spanText && /\d/.test(spanText)) return spanText;
+        }
+
+        const decoded = decodeHTML(section);
+        if (decoded) {
+            const dateMatch = /(\d{4}[.\/-]\d{1,2}[.\/-]\d{1,2}|\d{1,2}[.\/]\d{1,2}[.\/]\d{2,4})/.exec(decoded);
+            if (dateMatch?.[1]) return dateMatch[1];
+        }
+    }
+
+    return null;
+};
+
 const parseNameAndTag = (value: string): { name: string; tag?: string } => {
     const trimmed = value.trim();
     if (!trimmed) return { name: '' };
@@ -397,24 +461,31 @@ const parseHeaderInfo = (html: string, profile: FreeCompanyProfile) => {
         }
     }
 
-    const crestBaseMatch = /<img[^>]+src="([^"]+)"[^>]*class="[^"]*freecompany__crest__base[^"]*"[^>]*>/i.exec(html);
-    if (crestBaseMatch?.[1]) {
-        profile.crest = crestBaseMatch[1];
-    }
+    const crestBlock = /<div[^>]*class="freecompany__crest__image"[^>]*>([\s\S]*?)<\/div>/i.exec(html);
+    const crestOverlays = crestBlock
+        ? Array.from(
+            crestBlock[1]?.matchAll(/<img[^>]+(?:data-src|src)="([^"]+)"[^>]*>/gi) ?? [],
+        )
+            .map(match => match[1])
+            .filter((src): src is string => Boolean(src))
+        : [];
 
-    if (!profile.crest) {
-        const crestBlock = /<div[^>]*class="freecompany__crest__image"[^>]*>([\s\S]*?)<\/div>/i.exec(html);
-        if (crestBlock) {
-            const images = Array.from(crestBlock[1]?.matchAll(/<img[^>]+src="([^"]+)"[^>]*>/gi) ?? []);
-            const crest = images.at(-1)?.[1] ?? images[0]?.[1];
-            if (crest) profile.crest = crest;
-        }
-    }
+    const crestBaseMatch = /<img[^>]+(?:data-src|src)="([^"]+)"[^>]*class="[^"]*freecompany__crest__base[^"]*"[^>]*>/i.exec(html);
+    const crestFallback = /<div[^>]*class="freecompany__crest"[^>]*>([\s\S]*?)<\/div>/i.exec(html);
+    const crestFallbackImage = crestFallback
+        ? /<img[^>]+(?:data-src|src)="([^"]+)"[^>]*>/i.exec(crestFallback[1] ?? '')
+        : null;
 
-    if (!profile.crest) {
-        const crestFallback = /<div[^>]*class="freecompany__crest"[^>]*>([\s\S]*?)<\/div>/i.exec(html);
-        const crest = crestFallback ? /<img[^>]+src="([^"]+)"[^>]*>/i.exec(crestFallback[1] ?? '') : null;
-        if (crest?.[1]) profile.crest = crest[1];
+    const crestCandidates = [
+        crestOverlays.at(-1),
+        crestOverlays[0],
+        crestBaseMatch?.[1],
+        crestFallbackImage?.[1],
+    ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+
+    const crestCandidate = crestCandidates[0];
+    if (crestCandidate) {
+        profile.crest = crestCandidate;
     }
 };
 
@@ -539,7 +610,15 @@ export async function fetchFreeCompanyProfile(
     if (!profile.slogan && sloganMatch) profile.slogan = decodeHTML(sloganMatch[1] ?? '');
 
     const formedDetail = extractDetail(html, 'Formed');
-    if (formedDetail?.text) profile.formed = formedDetail.text;
+    if (formedDetail) {
+        const formedValue = parseFormedDetail(formedDetail);
+        if (formedValue) profile.formed = formedValue;
+    }
+
+    if (!profile.formed || !/\d/.test(profile.formed)) {
+        const fallbackFormed = extractFormedDateFromHtml(html);
+        if (fallbackFormed) profile.formed = fallbackFormed;
+    }
 
     const membersDetail = extractDetail(html, 'Active Members');
     if (membersDetail?.text) profile.members = membersDetail.text;


### PR DESCRIPTION
## Summary
- ensure focus list deduplication always returns canonical focus entries even when emojis are present
- add timestamp and markup fallbacks to reliably capture the Free Company formed date from Lodestone pages
- prefer crest overlay assets so embeds render the actual emblem instead of the blank base layer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cea7d583ac8321999cb0c985913d86