### PR TITLE
Fix crest image fetching

### DIFF
--- a/src/types/sharp.d.ts
+++ b/src/types/sharp.d.ts
@@ -1,0 +1,1 @@
+declare module 'sharp';


### PR DESCRIPTION
## Summary
- add browser-like headers and alternate domain fallbacks when fetching Free Company crest layers so Discord receives a composed image
- declare a local sharp module stub so TypeScript can compile when building the crest attachment helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cedd4abf348321ad7229a3ee69c98a